### PR TITLE
Hopefully no nested anchor tags

### DIFF
--- a/exporters/common/apparatus-global.xsl
+++ b/exporters/common/apparatus-global.xsl
@@ -97,7 +97,7 @@
   </xsl:template>
 
   <xsl:template match="t:choice[t:abbr and t:expan]">
-    <xsl:element name="a">
+    <xsl:element name="span"> <!-- used to be a -->
       <xsl:attribute name="title">
 	<xsl:for-each select="t:expan">
 	<xsl:value-of select="."/><xsl:if test="position() &lt; last()">; </xsl:if>
@@ -119,8 +119,12 @@
 	</xsl:attribute>
       </xsl:if>
       <span class="symbol comment">&#9658;</span> 
-      <xsl:apply-templates/>
+      <xsl:comment> moved the content till after the anchor </xsl:comment>
     </xsl:element>
+    <span>
+      <xsl:attribute name="title">Kommentar</xsl:attribute>
+      <xsl:apply-templates/>
+    </span>
   </xsl:template>
 
   <xsl:template match="t:seg[@type='com']">
@@ -138,9 +142,16 @@
 	<xsl:call-template name="add_id"/>
       </xsl:otherwise>
       </xsl:choose>
-      <span class="symbol comment">&#9658;</span> 
-      <xsl:apply-templates/>
+      <span class="symbol comment">&#9658;</span>
+      <xsl:comment> moved the content till after the anchor </xsl:comment>
+
     </xsl:element>
+
+    <span>
+      <xsl:attribute name="title">Kommentar</xsl:attribute>
+      <xsl:apply-templates/>
+    </span>
+    
   </xsl:template>
 
   <xsl:template match="t:note">

--- a/exporters/gv/render.xsl
+++ b/exporters/gv/render.xsl
@@ -19,10 +19,8 @@
     <xsl:variable name="href">
       <xsl:value-of select="concat(fn:replace($path,'txt-((root)|(shoot).*$)','com-root#'),@n)"/>
     </xsl:variable>
-    <a class="comment" title="Kommentar" id="{@n}" href="{$href}"><span class="symbol comment">&#9658;</span> <xsl:apply-templates/></a>
+    <a class="comment" title="Kommentar" id="{@n}" href="{$href}"><span class="symbol comment">&#9658;</span></a>  <span class="comment"><xsl:apply-templates/></span>
   </xsl:template>
-
-
 
   <xsl:template name="make-href">
 


### PR DESCRIPTION
When the apparatus becomes complex there was a risk for nested hierarchies of <a> .... </a> tags. By only make anchors of the symbols for comment, person, place etc, not the text to be explained we may have a person link inside comment reference etc most places which earlier had problems now works.

http://text-test-02.kb.dk/text/sks-ee1-txt-shoot-idcf57b8e7-76ac-45ce-802d-bfd5b5acc75c