### PR TITLE
tfs3 & toc works again

### DIFF
--- a/exporters/common/open-seadragon-config.xq
+++ b/exporters/common/open-seadragon-config.xq
@@ -42,7 +42,7 @@ declare function local:get-facs($pid as xs:string*,$doc as node() ) as xs:string
 {
    let $uri_path := 
 	if($doc//t:graphic[@xml:id=$pid]/@url) then fn:replace($doc//t:graphic[@xml:id=$pid]/@url,"(^.*geService/)(.*)(.jpg)","$2")
-	else if(contains($path,"tfs")) then  concat("/public/tekstportal/tfs/",$pid)
+	else if(contains($path,"tfs")) then  concat("/public/tekstportal/tfs3/",$pid) (: because of caching problem :)
 	else if(contains($path,"gv") ) then  concat("/public/tekstportal/gv/", $pid)
   else concat("public/",$pid)
   return  string-join((concat($uri_scheme,"://kb-images.kb.dk"),$uri_path,"info.json"),'/')
@@ -111,7 +111,7 @@ declare function local:get-pages(
 declare function local:get-graphic-uri($pid as xs:string,$doc as node()) as xs:string*
 {
 	let $pth := 
-	if(contains($path,"tfs")) then "public/tekstportal/tfs/"
+	if(contains($path,"tfs")) then "public/tekstportal/tfs3/"
 	else if(contains($path,"gv")) then "public/tekstportal/gv/"
 	else "public/"
 

--- a/exporters/common/toc-global.xsl
+++ b/exporters/common/toc-global.xsl
@@ -65,7 +65,7 @@ Author Sigfrid Lundberg slu@kb.dk
   </xsl:template>
 
   <xsl:template match="t:head">
-    <xsl:call-template name="some_text"/>
+    <xsl:apply-templates/>
   </xsl:template>
 
   <xsl:template match="t:lb">
@@ -144,7 +144,7 @@ Author Sigfrid Lundberg slu@kb.dk
   
   <xsl:template name="some_text">
     <xsl:variable name="head_text">
-      <xsl:apply-templates select=".//t:head"/>
+      <xsl:apply-templates  mode="collect_text" select=".//t:head"/>
     </xsl:variable>
     <xsl:choose>
       <xsl:when test="string-length($head_text) &gt; 5">


### PR DESCRIPTION
The new place for images is under tfs3 in IIP and we adjust the open sea dragon config accordingly.
We also commit the fix for apparatus text in tocs.

