### PR TITLE
Gv apps again

### DIFF
--- a/exporters/common/apparatus-global.xsl
+++ b/exporters/common/apparatus-global.xsl
@@ -338,9 +338,11 @@
 
     <span style="background-color:Aquamarine;display:none;">
       <xsl:call-template name="add_id"/>
-      <xsl:apply-templates mode="apparatus" select="t:lem"/>
+      <xsl:apply-templates mode="apparatus" select="t:lem"/><xsl:if test="t:rdg|t:rdgGrp|t:corr|t:note">,
+    </xsl:if>
       <xsl:for-each select="t:rdg|t:rdgGrp|t:corr|t:note">
-	<xsl:apply-templates mode="apparatus"  select="."/><!-- xsl:if test="position() &lt; last()" -->;<xsl:comment> ; </xsl:comment><!-- /xsl:if -->
+	<xsl:apply-templates mode="apparatus"  select="."/><xsl:if test="position() &lt; last()">;
+        </xsl:if><xsl:comment> ; </xsl:comment><!-- /xsl:if -->
       </xsl:for-each><xsl:comment> <xsl:text> </xsl:text> app </xsl:comment>
     </span>
 

--- a/exporters/gv/render.xsl
+++ b/exporters/gv/render.xsl
@@ -41,29 +41,40 @@
   </xsl:template>
 
 
-  <xsl:template match="t:persName|t:placeName">
+
+
+  <!-- we leave the references to bible stuff, because addressing is far too complicated |t:rs[@type='bible'] -->
+  <xsl:template match="t:persName|t:placeName|t:rs[@type='myth']|t:rs[@type='title']">
     <xsl:variable name="entity">
       <xsl:choose>
 	<xsl:when test="contains(local-name(.),'pers')">person</xsl:when>
-	<xsl:otherwise>place</xsl:otherwise>
+        <xsl:when test="contains(local-name(.),'place')">place</xsl:when>
+	<xsl:otherwise>comment</xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
     <xsl:variable name="authority">
       <xsl:choose>
 	<xsl:when test="contains(local-name(.),'pers')">pers</xsl:when>
-	<xsl:otherwise>place</xsl:otherwise>
+        <xsl:when test="contains(local-name(.),'place')">place</xsl:when>
+        <xsl:when test="@type='myth'">myth</xsl:when>
+        <xsl:when test="@type='bible'">bible</xsl:when>
+	<xsl:otherwise>title</xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
     <xsl:variable name="symbol">
       <xsl:choose>
 	<xsl:when test="contains(local-name(.),'pers')">&#128100;</xsl:when>
-	<xsl:otherwise>&#128204;</xsl:otherwise>
+	<xsl:when test="contains(local-name(.),'place')">&#128204;</xsl:when>
+        <xsl:otherwise>&#9658;</xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
     <xsl:variable name="title">
-      <xsl:choose>
+        <xsl:choose>
 	<xsl:when test="contains(local-name(.),'pers')">Person</xsl:when>
-	<xsl:otherwise>Plads</xsl:otherwise>
+        <xsl:when test="contains(local-name(.),'place')">Plads</xsl:when>
+        <xsl:when test="@type='myth'">Mytologi</xsl:when>
+        <xsl:when test="@type='bible'">Bibel</xsl:when>
+	<xsl:otherwise>Titel</xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
     <span class="{$entity}">


### PR DESCRIPTION
Revisiting GV fixing:

- Adding a comma between readings in the critical apparatus
- GV now resolves references of all kinds except to bible verses and the like. I.e., to persons, places, mythological entities and literature refs.

Those bible things are cross references between documents. Had the IDs and IDREFS been OK syntactically (NCName) I might consider to implement them.